### PR TITLE
Disable internal transactions fetcher

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -34,6 +34,7 @@ services:
         ETHEREUM_JSONRPC_WS_URL: wss://testnet-rpc.atleta.network:9944/
         ETHEREUM_JSONRPC_VARIANT: 'geth'
         CHAIN_ID: '2340'
+        INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER: true
 
   visualizer:
     extends:


### PR DESCRIPTION
Blockscout has configuration to on/off internal transactions.
This PR disables fetcher at all as node API do not support required rpc methods yet.

Also I've found in [docs](https://docs.blockscout.com/for-developers/information-and-settings/env-variables#indexer-management) variable named `INDEXER_INTERNAL_TRANSACTIONS_TRACER_TYPE` for tune this fetcher.
Maybe can be useful in future.